### PR TITLE
Add grill-me and grilling skills

### DIFF
--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: grill-me
+description: A relentless interview to sharpen a plan or design.
+disable-model-invocation: true
+---
+
+Run a `/grilling` session.

--- a/.claude/skills/grilling/SKILL.md
+++ b/.claude/skills/grilling/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: grilling
+description: Grill the user relentlessly about a plan or design. Use when the user wants to stress-test a plan before building, or uses any 'grill' trigger phrases.
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
+
+If a *fact* can be found by exploring the codebase, look it up rather than asking me. The *decisions*, though, are mine — put each one to me and wait for my answer.
+
+Do not enact the plan until I confirm we have reached a shared understanding.


### PR DESCRIPTION
## 概要

[mattpocock/skills](https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md) の `grill-me` スキルを追加しました。

## 変更内容

- `.claude/skills/grill-me/SKILL.md` — 計画・設計を鍛えるための厳しいインタビューを開始するスキル。`/grilling` セッションを起動します（`disable-model-invocation: true` のためユーザーが明示的に呼び出したときのみ動作）。
- `.claude/skills/grilling/SKILL.md` — `grill-me` が依存するスキル。計画をビルド前にストレステストするため、依存関係を一つずつ解決しながら 1 問ずつ質問していきます。事実はコードベースを調べて確認し、意思決定はユーザーに委ねます。

`grill-me` は `/grilling` を呼び出すだけのランチャーなので、単体で機能するよう両方のスキルを追加しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzMT7M8VzbNnSygmf3c817)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “grill-me” workflow for starting focused planning and design review sessions.
  * Added a structured “grilling” workflow that asks targeted questions, verifies details, and requires confirmation before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->