### PR TITLE
fix(ci): allow renovate bot in claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,8 @@ jobs:
         uses: anthropics/claude-code-action@v1.0.178
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # v1.0.178 以降、bot 起点の実行は allowed_bots に列挙が必要 (Renovate PR で CI が落ちる)
+          allowed_bots: renovate
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## 概要

Renovate 起点の PR で `claude-review` check が失敗する問題の修正。

- 失敗 run: https://github.com/kanade0404/resume/actions/runs/29685256320 (PR #97)
- エラー: `Workflow initiated by non-human actor: renovate (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.`

## Root cause

`anthropics/claude-code-action` は `allowed_bots` 未指定 (default: 空 = bot 全拒否) の場合、bot 起点の workflow 実行を拒否する。#98 で v1.0.178 へ更新後、Renovate が rebase した PR #97 の run が renovate[bot] アクターで走り、この検査に落ちた。

## 対応

`allowed_bots: renovate` を追加し、Renovate PR でも従来どおり claude-review を走らせる (`*` は使わず renovate のみ許可)。action 側は `[bot]` サフィックスを正規化して比較するため `renovate` 表記で一致する。

マージ後、PR #97 の `claude-review` を re-run すれば merge ref 経由で修正済み workflow が使われ、緑になる想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TP4jndXmvdKv2UQepXwPMf

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kanade0404/resume/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 自動コードレビューの実行条件を更新し、Renovateによって開始された処理のみが対象となるよう制御を追加しました。
  * 対象外のボットによる不要なレビュー実行を抑制し、レビュー処理の安定性と予測可能性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->