### PR TITLE
fix(renovate): align minimumReleaseAge with pnpm supply-chain policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>kanade0404/renovate-config"
-  ]
+  ],
+  "minimumReleaseAge": "1 day"
 }


### PR DESCRIPTION
## 概要

新リリース直後のパッケージを含むRenovate PRが、最初の24時間必ずtextlint jobで落ちる問題の恒久対応。

- 実例1: rulesync@14.1.0 の PR #97 (公開から23時間52分の時点のrunで失敗、24時間経過後のre-runで成功)
- 実例2: rulesync@15.1.0 の PR #106 (現在も同エラーで失敗中: https://github.com/kanade0404/resume/actions/runs/30198780059)

## Root cause

pnpm 11のデフォルトsupply-chainポリシー `minimumReleaseAge` (24時間) により、公開から24時間未満のパッケージを含むlockfileはCIの `pnpm install` が `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` で拒否する。一方Renovateは公開直後でも即PRを作成・rebaseするため、両者の設定が衝突し、新リリースのPRは最初の24時間構造的にCIが赤になる。

## 対応

`renovate.json` に `"minimumReleaseAge": "1 day"` を追加し、Renovateが公開から24時間経過したバージョンのみPR化するようにする。PR作成時点でpnpmポリシーを満たすため、この失敗クラスが消える。

### トレードオフ

- 依存更新のPR化が最大24時間遅れる(supply-chain攻撃対策としてはむしろ推奨されるプラクティス)
- `vulnerabilityAlerts` 起点のsecurity PRはRenovateの仕様上この待機の影響を受けにくいが、緊急の脆弱性対応を最速で取り込みたい場合は個別に手動対応する余地を残す

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TP4jndXmvdKv2UQepXwPMf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * リリース後の変更を一定期間保留する設定を追加しました。
  * Renovateの設定ファイルを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->